### PR TITLE
fix: replaced broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ At some point, we'll also use the following extensions:
 
 - [Colour contrast checker](https://colourcontrast.cc/) - Chrome only
 - [Web Developer](https://chrispederick.com/work/web-developer/) - Chrome or Firefox
-- [headingsMap](https://www.learningapps.co.uk/moodle/xertetoolkits/play.php?template_id=1309#page1section3) - Chrome or Firefox
+- [HeadingsMap](https://rumoroso.bitbucket.io/) - Chrome or Firefox
 
 ## Screen Readers
 

--- a/src/briefings/1.1.html
+++ b/src/briefings/1.1.html
@@ -51,7 +51,7 @@ there's a layout implemented that looks good but the semantics are a mess.</p>
 <p><strong>Hint:</strong> What CSS will you use at <code>.visually-hidden</code>? There are better ways to hide content than using <code>display: none;</code>. Check how to <a href="https://a11yproject.com/posts/how-to-hide-content/">visually hide content</a>.</p>
 <h2 id="furtherreading">Further reading</h2>
 <ul>
-<li><a href="https://www.learningapps.co.uk/moodle/xertetoolkits/play.php?template_id=1309#page1section3">Extension <code>headingsMap</code></a> - Chrome or Firefox</li>
+<li><a href="https://rumoroso.bitbucket.io/">Extension <code>HeadingsMap</code></a> - Chrome or Firefox</li>
 <li><a href="https://www.a11yproject.com/posts/how-to-accessible-heading-structure/">Accessible heading structure</a></li>
 <li><a href="https://a11yproject.com/posts/how-to-hide-content/">How to hide content</a></li>
 <li><a href="https://www.smashingmagazine.com/2020/01/html5-article-section/">HTML5 deep dive into article and section</a></li>

--- a/src/briefings/1.1.md
+++ b/src/briefings/1.1.md
@@ -55,7 +55,7 @@ We can visually understand that the plant is on sale ($40 to $30). However, if w
 
 ## Further reading
 
-- [Extension `headingsMap`](https://www.learningapps.co.uk/moodle/xertetoolkits/play.php?template_id=1309#page1section3) - Chrome or Firefox
+- [Extension `HeadingsMap`](https://rumoroso.bitbucket.io/) - Chrome or Firefox
 - [Accessible heading structure](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/)
 - [How to hide content](https://a11yproject.com/posts/how-to-hide-content/)
 - [HTML5 deep dive into article and section](https://www.smashingmagazine.com/2020/01/html5-article-section/)

--- a/src/briefings/3.2.html
+++ b/src/briefings/3.2.html
@@ -68,7 +68,7 @@ There's no better way to discover it than by using it yourself with a screen rea
 <h2 id="furtherreading">Further reading</h2>
 <ul>
 <li><a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles">Aria Roles</a></li>
-<li><a href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html">W3C Landmarks Example</a></li>
+<li><a href="https://w3c.github.io/aria-practices/examples/landmarks/main.html">W3C Landmarks Example</a></li>
 <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks browser extension</a></li>
 <li>A 2020 study to the top 1 million webpages revelated that <a href="https://webaim.org/projects/million/#languages">~29% of the websites</a> didn't specify the document language.</li>
 <li><a href="https://www.smashingmagazine.com/2020/01/html5-article-section/">HTML5 deep dive into article and section</a></li>

--- a/src/briefings/3.2.md
+++ b/src/briefings/3.2.md
@@ -78,7 +78,7 @@ There's no better way to discover it than by using it yourself with a screen rea
 ## Further reading
 
 - [Aria Roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)
-- [W3C Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html)
+- [W3C Landmarks Example](https://w3c.github.io/aria-practices/examples/landmarks/main.html)
 - [Landmarks browser extension](http://matatk.agrip.org.uk/landmarks/)
 - A 2020 study to the top 1 million webpages revelated that [~29% of the websites](https://webaim.org/projects/million/#languages) didn't specify the document language.
 - [HTML5 deep dive into article and section](https://www.smashingmagazine.com/2020/01/html5-article-section/)

--- a/src/briefings/4.3.html
+++ b/src/briefings/4.3.html
@@ -65,7 +65,7 @@
 </ul>
 <h3 id="accordion">Accordion</h3>
 <ul>
-<li>Tutorial: <a href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html">WAI ARIA Practices</a></li>
+<li>Tutorial: <a href="https://w3c.github.io/aria-practices/examples/accordion/accordion.html">WAI ARIA Practices</a></li>
 </ul>
 <!-- -->
 <style>

--- a/src/briefings/4.3.md
+++ b/src/briefings/4.3.md
@@ -54,7 +54,7 @@ Before you use an "accessible package" from the community, don't get sold by ["s
 
 ### Accordion
 
-- Tutorial: [WAI ARIA Practices](https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html)
+- Tutorial: [WAI ARIA Practices](https://w3c.github.io/aria-practices/examples/accordion/accordion.html)
 
 <!-- -->
 


### PR DESCRIPTION
Just a quick fix for some broken links.

1. **HeadingsMap Extension**
This link is dead https://www.learningapps.co.uk/moodle/xertetoolkits/play.php?template_id=1309#page1section3.  
I hope https://rumoroso.bitbucket.io/ is a good replacement.

2. **W3C Landmarks Example**
This link is dead https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html.  
I had a look at archive.org and replaced the link with https://w3c.github.io/aria-practices/examples/landmarks/main.html.

3. **Accordion WAI ARIA Practices**
This link is dead https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html.  
I had a look at archive.org and replaced the link with https://w3c.github.io/aria-practices/examples/accordion/accordion.html.